### PR TITLE
fix incorrect path to platform-release workflow

### DIFF
--- a/.github/workflows/sync-global-workflows.yml
+++ b/.github/workflows/sync-global-workflows.yml
@@ -24,7 +24,7 @@ jobs:
         uses: derberg/copy-files-to-other-repositories@v1.0.0
         with:
           github_token: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
-          patterns_to_include: .github/workflows/platform-check.yml,workflows/platform-release.yml
+          patterns_to_include: .github/workflows/platform-check.yml,.github/workflows/platform-release.yml
           patterns_to_ignore: .github/workflows/sync-global-workflows.yml
           topics_to_include: platform-tf-module
           exclude_private: true


### PR DESCRIPTION
Found an error after running the pipeline where the reference to the platform-release workflow was missing the .github prefix.