### PR TITLE
use forked community action with recursive readdir fix

### DIFF
--- a/.github/workflows/sync-global-workflows.yml
+++ b/.github/workflows/sync-global-workflows.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating files
-        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        uses: bbleau/copy-files-to-other-repositories@fix/workflow-dispatch-readdir-recursively
         with:
           github_token: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
           patterns_to_include: .github/workflows/platform-check.yml,.github/workflows/platform-release.yml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ The repo prefix is itself prefixed witht the higher level team managing the repo
 - Create/Commit workflow file to the .github/workflows directory
 - Manually disable new workflow in this repo if it does not apply to the .github repo
 
+### Adding a repo
+
+If a workflow already exists that fits the repos need you can add a topic to the repo and have it included in the sync process.
+
+- In your repo click the gear icon on the right of the of the about section on the right hand side of the code tab.
+- In the model under the field label `Topics` type the corrisponding topic relating to the workflow.
+- Save your changes, closing the model.
+- In the `.github` repo under the actions tab select `sync-global-workflows` in the workflows list.
+- Click the `Run workflow` button in the middle right of the page and type the name of your target repository
+- Click the green `Run workflow` to execute the workflow
+
 ### Resources & Links
 
 - https://github.blog/2017-01-31-introducing-topics/


### PR DESCRIPTION
Fixes an issue found in the community action where the workflow dispatch flow of the action was only looking one level deep via nodejs readdir function instead of getting the all the files in the specified path.